### PR TITLE
Map C-[ to close window

### DIFF
--- a/lua/key-menu.lua
+++ b/lua/key-menu.lua
@@ -612,6 +612,7 @@ local function open_window(prefix)
     vim.keymap.set('n', '<C-[>', close_window, {buffer=buf, nowait=true})
     vim.keymap.set('n', '<C-c>', close_window, {buffer=buf, nowait=true})
     vim.keymap.set('n', '<BS>', backspace, {buffer=buf, nowait=true})
+    vim.keymap.set('n', '<C-h>', backspace, {buffer=buf, nowait=true})
   end
 
   vim.api.nvim_create_autocmd("BufLeave", {buffer=buf, callback=close_window})

--- a/lua/key-menu.lua
+++ b/lua/key-menu.lua
@@ -609,6 +609,7 @@ local function open_window(prefix)
 
   add_default_mappings = function()
     vim.keymap.set('n', '<Esc>', close_window, {buffer=buf, nowait=true})
+    vim.keymap.set('n', '<C-[>', close_window, {buffer=buf, nowait=true})
     vim.keymap.set('n', '<C-c>', close_window, {buffer=buf, nowait=true})
     vim.keymap.set('n', '<BS>', backspace, {buffer=buf, nowait=true})
   end


### PR DESCRIPTION
> Neovim 0.7 now correctly [distinguishes these modifier key combos](https://github.com/neovim/neovim/pull/17825) in its own input processing, so users can now map e.g. <Tab> and <C-I> separately. In addition, Neovim sends an [escape sequence](https://github.com/neovim/neovim/pull/17844) on startup that signals to the controlling terminal emulator that it supports this style of key encoding. Some terminal emulators (such as iTerm2, foot, and tmux) use this sequence to programatically enable the different encoding.

Since 0.7 it's possible for Neovim to distinguish `<C-[>` and `<Esc>` thus on my end `<C-[>` no longer behaves like I expect `<Esc>` would (close the window). Not sure if this is what you or the general users want, but I see no way to map this without changing the source code. While at it, I also mapped `<C-h>` to backspace. Open to suggestions.

Anyway, thanks for the plugin and I loved reading [how it works](https://github.com/linty-org/key-menu.nvim#how-it-works)!